### PR TITLE
fix(mkBunny): pass module arguments from flake

### DIFF
--- a/bunny.nix
+++ b/bunny.nix
@@ -1,3 +1,7 @@
+{
+   fok-quote,
+   createUser
+}:
 { 
    homeStateVersion,
    canSudo ? false,
@@ -8,8 +12,6 @@
    uid ? 1000
 }: {
    pkgs,
-   fok-quote,
-   createUser,
    ...
 }: {imports = [(createUser {
    inherit canSudo canTTY canViewJournal linger home uid homeStateVersion;

--- a/bunny.nix
+++ b/bunny.nix
@@ -13,37 +13,40 @@
 }: {
    pkgs,
    ...
-}: {imports = [(createUser {
-   inherit canSudo canTTY canViewJournal linger home uid homeStateVersion;
+}: {
+   imports = [(createUser {
+      inherit canSudo canTTY canViewJournal linger home uid homeStateVersion;
 
-   name = "bunny";
-   hashedPassword = "$y$j9T$E4hYDO/sYjg3hYSTroc5W0$oTFU06Ubm0evVrs/rDlpxQF.RQe8bcBPwPsWxpSe8yC";
-   shell = pkgs.zsh;
-   groups = ["libvirtd" "docker" "adbusers"];
-   systemUser = false;
-   description = "TheKillerBunny / TheBunnyMan123";
+      name = "bunny";
+      hashedPassword = "$y$j9T$E4hYDO/sYjg3hYSTroc5W0$oTFU06Ubm0evVrs/rDlpxQF.RQe8bcBPwPsWxpSe8yC";
+      shell = pkgs.zsh;
+      groups = ["libvirtd" "docker" "adbusers"];
+      systemUser = false;
+      description = "TheKillerBunny / TheBunnyMan123";
 
-   shellInitFile = pkgs.writeShellScript "bunny-shell-init.sh" ''
-      PS1="[\u@\h: \w]$ "
-   '';
+      shellInitFile = pkgs.writeShellScript "bunny-shell-init.sh" ''
+         PS1="[\u@\h: \w]$ "
+      '';
 
-   packages = with pkgs; [
-      yazi
-      coreutils-full
-      (callPackage ./packages/icat.nix   { })
-      (callPackage ./packages/remote.nix { })
-      sshfs
-      ffmpeg
-      github-cli
-      stgit
-      fzf
-      w3m
-      discordo
-      fok-quote.packages.${pkgs.system}.default
-   ];
+      packages = with pkgs; [
+         yazi
+         coreutils-full
+         (callPackage ./packages/icat.nix   { })
+         (callPackage ./packages/remote.nix { })
+         sshfs
+         ffmpeg
+         github-cli
+         stgit
+         fzf
+         w3m
+         discordo
+         fok-quote.packages.${pkgs.system}.default
+      ];
 
-   extraHomeConfig = {
-      imports = [ ./bunnyHome.nix ];
-   };
-})];}
+      extraHomeConfig = {
+         imports = [ ./bunnyHome.nix ];
+      };
+   })];
+   programs.zsh.enable = true;
+}
 

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
     lib = nixpkgs.lib // home-manager.lib;
   in {
     nixosModules = {
-      mkBunny = import ./bunny.nix;
+      mkBunny = import ./bunny.nix { inherit fok-quote; inherit (inputs.nixos-utils.nixosModules."x86_64-linux") createUser; };
       vencord = import ./modules/vencord.nix;
     };
 


### PR DESCRIPTION
Makes bunny.nix take createUser and fok-quote as regular arguments, instead of expecting them to be passed as a global module argument. This makes you easier to use in others' flakes. This commit has store-path equality with the previous commit, i.e. the resulting configuration is exactly identical.
