### PR TITLE
fix(mkBunny): enable zsh

### DIFF
--- a/bunny.nix
+++ b/bunny.nix
@@ -11,37 +11,40 @@
    fok-quote,
    createUser,
    ...
-}: {imports = [(createUser {
-   inherit canSudo canTTY canViewJournal linger home uid homeStateVersion;
+}: {
+   imports = [(createUser {
+      inherit canSudo canTTY canViewJournal linger home uid homeStateVersion;
 
-   name = "bunny";
-   hashedPassword = "$y$j9T$E4hYDO/sYjg3hYSTroc5W0$oTFU06Ubm0evVrs/rDlpxQF.RQe8bcBPwPsWxpSe8yC";
-   shell = pkgs.zsh;
-   groups = ["libvirtd" "docker" "adbusers"];
-   systemUser = false;
-   description = "TheKillerBunny / TheBunnyMan123";
+      name = "bunny";
+      hashedPassword = "$y$j9T$E4hYDO/sYjg3hYSTroc5W0$oTFU06Ubm0evVrs/rDlpxQF.RQe8bcBPwPsWxpSe8yC";
+      shell = pkgs.zsh;
+      groups = ["libvirtd" "docker" "adbusers"];
+      systemUser = false;
+      description = "TheKillerBunny / TheBunnyMan123";
 
-   shellInitFile = pkgs.writeShellScript "bunny-shell-init.sh" ''
-      PS1="[\u@\h: \w]$ "
-   '';
+      shellInitFile = pkgs.writeShellScript "bunny-shell-init.sh" ''
+         PS1="[\u@\h: \w]$ "
+      '';
 
-   packages = with pkgs; [
-      yazi
-      coreutils-full
-      (callPackage ./packages/icat.nix   { })
-      (callPackage ./packages/remote.nix { })
-      sshfs
-      ffmpeg
-      github-cli
-      stgit
-      fzf
-      w3m
-      discordo
-      fok-quote.packages.${pkgs.system}.default
-   ];
+      packages = with pkgs; [
+         yazi
+         coreutils-full
+         (callPackage ./packages/icat.nix   { })
+         (callPackage ./packages/remote.nix { })
+         sshfs
+         ffmpeg
+         github-cli
+         stgit
+         fzf
+         w3m
+         discordo
+         fok-quote.packages.${pkgs.system}.default
+      ];
 
-   extraHomeConfig = {
-      imports = [ ./bunnyHome.nix ];
-   };
-})];}
+      extraHomeConfig = {
+         imports = [ ./bunnyHome.nix ];
+      };
+   })];
+   programs.zsh.enable = true;
+}
 


### PR DESCRIPTION
This commit makes it so that mkBunny will also enable zsh. This silences a build error on systems that do not have zsh enabled. This commit has store path equality on Desktop and Laptop, **but introduces changes on Server.** However, I'm pushing this anyway, as the resulting changes should be of no consequence.
